### PR TITLE
feat!: Store `viewColumn` for each tab added to a context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Starting at `v1.0.0` this project will follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html). `v0.x` can be considered a beta version.
 
 ## Unreleased
-- 
+
+### Added
+
+- Store `viewColumn` position for each file
+
+### Breaking changes
+
+- By storing `viewColumn` it makes the old file storage incompatible, so once you select a new task
 
 ## 0.3.0 - 2022-10-08
+
 - Upgrade all dependencies
 - Update icons to use [vscode-codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html).
 - Replace `TextDocument` by `Tab` and `TabGroup`.
@@ -23,19 +31,23 @@ Starting at `v1.0.0` this project will follow [Semantic Versioning](https://semv
 - Ask to add files when no task is active (#8)
 
 ### Fixes
+
 - Replace 'get' by 'update' on workspace method used on State.
 
 ### Security
+
 - Upgrade mocha to remove 'Prototype Pollution' from a dependency.
 - Upgrade y18n and lodash due to `npm audit` recommendations.
 
 ### Breaking changes
+
 - The state of the extension is now saved in the reserved space by VS Code. `keep-context.json` will not be created.
 - Upgrade project dependencies.
 
 ## 0.1.2 - 2019-12-21
 
 ### Fixes
+
 - Fix `https-proxy-agent` [vulnerability](https://www.npmjs.com/advisories/1184) with `npm audit`.
 - Remove file from task when it was not found in the file system.
 - Set `activeTask` as `null` when not found in the task's list.
@@ -43,6 +55,7 @@ Starting at `v1.0.0` this project will follow [Semantic Versioning](https://semv
 ## 0.1.1 - 2019-10-06
 
 ### Fixes
+
 - Fix `Settings.initialize`on first run (create `.vscode` if not exists).
 
 ## 0.1.0 - 2019-10-05

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ With this extension you won't forget the files that you need to open to continue
 ### Task management
 
 In a simple way you can:
+
 - Create/edit/delete task
 - Track opened files by task
 - Track git branch by task
@@ -25,9 +26,17 @@ In a simple way you can:
 ## Limitations
 
 - It may work in workspaces with more than one folder, but it only supports single folders.
-- Layouts cannot be restored properly https://github.com/microsoft/vscode/issues/88612
 - It doesn't store `TabInputTextDiff`, `TabInputWebview`, `TabInputNotebookDiff`, and `TabInputTerminal`.
 - Preview tabs are not stored.
+
+### Layouts / Columns
+
+VS Code uses `viewColumn` property to know the `tabGroup` a `tab` belongs to. But there is no what to know or set exact
+position of the tab which only goes from `1` to `9`.
+
+So if you place one group at the top and other at the bottom, the api just provide `1` and `2`. The same applies if you
+add one group at left and other at right. So the only information we give back when opening tabs is to which group the
+tab belongs.
 
 ## Known Issues
 

--- a/src/KeepContext.ts
+++ b/src/KeepContext.ts
@@ -8,7 +8,7 @@ import { createTask, getAllOpenedFiles, taskInputBox } from './utils';
 import State from './State';
 import { QuickPickTask } from './QuickPickTask';
 import { clearStatusBar, updateStatusBar } from './statusbar';
-import Task from './Task';
+import Task, { File } from './Task';
 import logger from './logger';
 
 /**
@@ -18,6 +18,7 @@ import logger from './logger';
  */
 export enum BuiltInCommands {
   CloseAllEditors = 'workbench.action.closeAllEditors',
+  SetEditorLayout = 'vscode.setEditorLayout',
 }
 
 /**
@@ -108,6 +109,7 @@ export default class KeepContext {
       }
 
       const fileNames = getAllOpenedFiles();
+      // const files = workspace.textDocuments.filter((doc) => doc.uri.scheme === 'file');
 
       if (!this.state.activeTask && fileNames.length > 0) {
         keepFilesOpened = await window
@@ -117,6 +119,10 @@ export default class KeepContext {
 
       if (keepFilesOpened) {
         task.files = fileNames;
+        // task.files = files.map<File>((doc) => ({
+        //   path: doc.uri.fsPath,
+        //   viewColumn: window.activeTextEditor?.viewColumn ?? ViewColumn.Active,
+        // }));
       }
 
       this.state.addTask(task);
@@ -235,6 +241,8 @@ export default class KeepContext {
         if (!keepFilesOpened) {
           task.files
             .filter((file) => {
+              // const hasFile = fs.existsSync(file.path);
+              // if (!hasFile) filesNotFound.push(file.path);
               const hasFile = fs.existsSync(file);
               if (!hasFile) filesNotFound.push(file);
               return hasFile;
@@ -305,6 +313,16 @@ export default class KeepContext {
     if (!task) return;
 
     task.files = files;
+
+    // if (!task.files.find((file) => file.path === fileName)) {
+    //   task.files.push({
+    //     path: fileName,
+    //     viewColumn: window.activeTextEditor?.viewColumn ?? ViewColumn.Active,
+    //   });
+    //   this.state.updateTask(task);
+    //   this.treeDataProvider.refresh();
+    // }
+
     this.state.updateTask(task);
     this.treeDataProvider.refresh();
   };

--- a/src/State.ts
+++ b/src/State.ts
@@ -58,17 +58,13 @@ export default class State {
     return this.workspaceState.get('tasks', {});
   }
 
+  /**
+   * Get a task by id
+   */
   getTask(taskId: string): Task | null {
     const task = this.tasks[taskId];
-
-    if (!task) {
-      return null;
-    }
-
-    return {
-      ...task,
-      files: [...task.files],
-    };
+    if (!task) return null;
+    return task;
   }
 
   addTask(task: Task): void {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -19,8 +19,7 @@ export default interface Task {
   /**
    * All the files opened in the editor while working in the task.
    */
-  files: string[];
-  // files: File[];
+  files: File[];
 
   /**
    * Branch attached to this task.

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -1,3 +1,10 @@
+import { ViewColumn } from 'vscode';
+
+export interface File {
+  path: string;
+  viewColumn?: ViewColumn;
+}
+
 export default interface Task {
   /**
    * Task ID.
@@ -13,6 +20,7 @@ export default interface Task {
    * All the files opened in the editor while working in the task.
    */
   files: string[];
+  // files: File[];
 
   /**
    * Branch attached to this task.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,29 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  // vscode.window.onDidChangeTextEditorViewColumn((textEditor: vscode.TextEditorViewColumnChangeEvent) => {
+  //   const state = State.getInstance();
+  //   debugger;
+  // });
+
+  // vscode.window.onDidChangeVisibleTextEditors((textEditors: vscode.TextEditor[]) => {
+  //   const state = State.getInstance();
+
+  //   if (state.activeTask) {
+  //     const task = state.tasks[state.activeTask];
+
+  //     textEditors.forEach(({ document, viewColumn }) => {
+  //       task.files = task.files.map((file) => {
+  //         if (file.path === getRealFileName(document)) {
+  //           file.viewColumn = viewColumn;
+  //         }
+  //         return file;
+  //       });
+  //     });
+  //     debugger;
+  //   }
+  // });
+
   context.subscriptions.push(keepContext.statusBarItem);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,29 +29,6 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
-  // vscode.window.onDidChangeTextEditorViewColumn((textEditor: vscode.TextEditorViewColumnChangeEvent) => {
-  //   const state = State.getInstance();
-  //   debugger;
-  // });
-
-  // vscode.window.onDidChangeVisibleTextEditors((textEditors: vscode.TextEditor[]) => {
-  //   const state = State.getInstance();
-
-  //   if (state.activeTask) {
-  //     const task = state.tasks[state.activeTask];
-
-  //     textEditors.forEach(({ document, viewColumn }) => {
-  //       task.files = task.files.map((file) => {
-  //         if (file.path === getRealFileName(document)) {
-  //           file.viewColumn = viewColumn;
-  //         }
-  //         return file;
-  //       });
-  //     });
-  //     debugger;
-  //   }
-  // });
-
   context.subscriptions.push(keepContext.statusBarItem);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import { Tab, TabInputCustom, TabInputNotebook, TabInputText, window } from 'vscode';
-import Task from './Task';
+import Task, { File } from './Task';
 
 /**
  * Returns an empty task structure.
@@ -70,13 +70,16 @@ export function isTabSupported(tab: Tab) {
 /**
  * Get a list of opened files supported by KeepContext.
  */
-export function getAllOpenedFiles() {
+export function getAllOpenedFiles(): File[] {
   return [
     ...new Set(
       window.tabGroups.all
         .flatMap((group) => group.tabs)
         .filter((tab) => !tab.isPreview && isTabSupported(tab))
-        .map(({ input }) => (input as KeepContextTabInput).uri.fsPath),
+        .map(({ input, group }) => ({
+          path: (input as KeepContextTabInput).uri.fsPath,
+          viewColumn: group.viewColumn,
+        })),
     ),
   ];
 }


### PR DESCRIPTION
VSCode only gives us `viewColumn` which gives us a "group id" but there is no way to say which its position was. When restore, VS Code takes care of the group position.