### PR TITLE
fix: Avoid race condition on editing files being created during checkout (#27)

### DIFF
--- a/src/GitProvider.ts
+++ b/src/GitProvider.ts
@@ -44,9 +44,9 @@ export default class GitProvider {
     }
   }
 
-  setBranch(branch: string): void {
+  async setBranch(branch: string): Promise<void> {
     if (this.branch === branch) return;
-    this.git.repositories[0]
+    await this.git.repositories[0]
       .checkout(branch)
       .then(() => (this.branch = branch))
       .catch((e) => logger.error(`Error during checkout of branch "${branch}"`, e));

--- a/src/KeepContext.ts
+++ b/src/KeepContext.ts
@@ -228,7 +228,7 @@ export default class KeepContext {
         state.activeTask = taskId;
 
         if (task.branch) {
-          this.git.setBranch(task.branch);
+          await this.git.setBranch(task.branch);
         }
 
         updateStatusBar(task.name);


### PR DESCRIPTION
This attempts to fix the race condition when you switch a task and the git checkout is creating new files that should be opened.

I simply added an await on the checkout command.

It seems to work in my manual testing.

Note that this means the new task does not activate until the checkout completes, which depending on the git repo size could be awhile.  But I think that makes sense as you need it checked out before you can really start working anyway.  At any rate, there would be a delay where the editors clear, it checks out, then editors start to open.