### PR TITLE
[WIP] feat: Add current line number to task context (#24)

### DIFF
--- a/src/KeepContext.ts
+++ b/src/KeepContext.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { commands, StatusBarAlignment, StatusBarItem, Uri, window, workspace } from 'vscode';
+import { commands, Position, Range, Selection, StatusBarAlignment, StatusBarItem, TextEditor, TextEditorRevealType, Uri, window, workspace } from 'vscode';
 
 import { ContextTreeDataProvider } from './ContextTreeDataProvider';
 import { ContextTreeItem } from './ContextTreeItem';
@@ -259,7 +259,13 @@ export default class KeepContext {
                       preview: false,
                       preserveFocus: true,
                     })
-                    .then(undefined, (e) =>
+                    .then((value) => {
+                      setTimeout(() => {
+                        const line = file.focusedLine || 0;
+                        value.selection = new Selection(new Position(line, 0), new Position(line, 0));
+                        value.revealRange(new Range(line, 0, line, 0), TextEditorRevealType.InCenterIfOutsideViewport);
+                      }, 80 * idx);
+                    }, (e) =>
                       logger.error(`Error showing file "${file.relativePath}" from "${file.workspaceFolder}"`, e),
                     );
                 }, 80 * idx);
@@ -317,6 +323,22 @@ export default class KeepContext {
 
     state.updateTask(task);
     this.treeDataProvider.refresh();
+  };
+
+  updateFocusedLine = (editor: TextEditor, line: number): void => {
+    if (!state.activeTask) return;
+
+    const task = state.getTask(state.activeTask);
+    if (!task) return;
+
+    task.files = task.files.map((file) => {
+      if (file.relativePath === workspace.asRelativePath(editor.document.uri)) {
+        file.focusedLine = line;
+        return file;
+      }
+      return file;
+    });
+    state.updateTask(task);
   };
 
   updateLayout = async () => {

--- a/src/Task.ts
+++ b/src/Task.ts
@@ -16,6 +16,11 @@ export interface File {
    * The location where this file should be.
    */
   viewColumn?: ViewColumn;
+
+  /**
+   * The line number to focus on in the editor.
+   */
+  focusedLine?: number;
 }
 
 export default interface Task {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,10 @@ export function activate(context: vscode.ExtensionContext): void {
     }
   });
 
+  context.subscriptions.push(vscode.window.onDidChangeTextEditorSelection(({ selections, textEditor }) => {
+    keepContext.updateFocusedLine(textEditor, selections[0].active.line);
+  }));
+
   vscode.workspace.onDidChangeConfiguration((event) => {
     if (event.affectsConfiguration(CONFIG_SECTION)) {
       changeStorage();


### PR DESCRIPTION
This adds tracking of the currently selected line number in editors and reveals the editor at that range when restoring windows on a task switch.

Currently, this is a bit buggy due to some sort of race condition.  Sometimes the selected range does not set in time so you wind up with the range stuck at 1.  It triggers pretty frequently at the moment, but this should be a good starting point.

Note that the current behavior is always to open the editor at line 1, so this bug does not provide any worse experience when it triggers.